### PR TITLE
general cleanup

### DIFF
--- a/bitcoin_utils.py
+++ b/bitcoin_utils.py
@@ -1,0 +1,158 @@
+import hashlib
+import struct
+from io import BytesIO
+from secp256k1 import ECKey
+from typing import Union
+
+
+def from_hex(hex_string):
+    """Deserialize from a hex string representation (e.g. from RPC)"""
+    return BytesIO(bytes.fromhex(hex_string))
+
+
+def ser_uint32(u: int) -> bytes:
+    return u.to_bytes(4, "big")
+
+
+def ser_uint256(u):
+    return u.to_bytes(32, 'little')
+
+
+def deser_uint256(f):
+    return int.from_bytes(f.read(32), 'little')
+
+
+def deser_txid(txid: str):
+    # recall that txids are serialized little-endian, but displayed big-endian
+    # this means when converting from a human readable hex txid, we need to first
+    # reverse it before deserializing it
+    dixt = "".join(map(str.__add__, txid[-2::-2], txid[-1::-2]))
+    return bytes.fromhex(dixt)
+
+
+def deser_compact_size(f):
+    nit = struct.unpack("<B", f.read(1))[0]
+    if nit == 253:
+        nit = struct.unpack("<H", f.read(2))[0]
+    elif nit == 254:
+        nit = struct.unpack("<I", f.read(4))[0]
+    elif nit == 255:
+        nit = struct.unpack("<Q", f.read(8))[0]
+    return nit
+
+
+def deser_string(f):
+    nit = deser_compact_size(f)
+    return f.read(nit)
+
+
+def deser_string_vector(f):
+    nit = deser_compact_size(f)
+    r = []
+    for _ in range(nit):
+        t = deser_string(f)
+        r.append(t)
+    return r
+
+
+class COutPoint:
+    __slots__ = ("hash", "n",)
+
+    def __init__(self, hash=b"", n=0,):
+        self.hash = hash
+        self.n = n
+
+    def serialize(self):
+        r = b""
+        r += self.hash
+        r += struct.pack("<I", self.n)
+        return r
+
+    def deserialize(self, f):
+        self.hash = f.read(32)
+        self.n = struct.unpack("<I", f.read(4))[0]
+
+
+class VinInfo:
+    __slots__ = ("outpoint", "scriptSig", "txinwitness", "prevout", "private_key")
+
+    def __init__(self, outpoint=None, scriptSig=b"", txinwitness=None, prevout=b"", private_key=None):
+        if outpoint is None:
+            self.outpoint = COutPoint()
+        else:
+            self.outpoint = outpoint
+        if txinwitness is None:
+            self.txinwitness = CTxInWitness()
+        else:
+            self.txinwitness = txinwitness
+        if private_key is None:
+            self.private_key = ECKey()
+        else:
+            self.private_key = private_key
+        self.scriptSig = scriptSig
+        self.prevout = prevout
+
+
+class CScriptWitness:
+    __slots__ = ("stack",)
+
+    def __init__(self):
+        # stack is a vector of strings
+        self.stack = []
+
+    def is_null(self):
+        if self.stack:
+            return False
+        return True
+
+
+class CTxInWitness:
+    __slots__ = ("scriptWitness",)
+
+    def __init__(self):
+        self.scriptWitness = CScriptWitness()
+
+    def deserialize(self, f):
+        if isinstance(f, list):
+            self.scriptWitness.stack = [deser_string(item) for item in f]
+        elif isinstance(f, str):
+            self.scriptWitness.stack = deser_string_vector(f)
+
+    def is_null(self):
+        return self.scriptWitness.is_null()
+
+
+def hash160(s: Union[bytes, bytearray]) -> bytes:
+    return hashlib.new("ripemd160", hashlib.sha256(s).digest()).digest()
+
+
+def is_p2tr(spk: bytes) -> bool:
+    if len(spk) != 34:
+        return False
+    # OP_1 OP_PUSHBYTES_32 <32 bytes>
+    return (spk[0] == 0x51) & (spk[1] == 0x20)
+
+
+def is_p2wpkh(spk: bytes) -> bool:
+    if len(spk) != 22:
+        return False
+    # OP_0 OP_PUSHBYTES_20 <20 bytes>
+    return (spk[0] == 0x00) & (spk[1] == 0x14)
+
+
+def is_p2sh(spk: bytes) -> bool:
+    if len(spk) != 23:
+        return False
+    # OP_HASH160 OP_PUSHBYTES_20 <20 bytes> OP_EQUAL
+    return (spk[0] == 0xA9) & (spk[1] == 0x14) & (spk[-1] == 0x87)
+
+
+def is_p2pkh(spk: bytes) -> bool:
+    if len(spk) != 25:
+        return False
+    # OP_DUP OP_HASH160 OP_PUSHBYTES_20 <20 bytes> OP_EQUALVERIFY OP_CHECKSIG
+    return (spk[0] == 0x76) & (spk[1] == 0xA9) & (spk[2] == 0x14) & (spk[-2] == 0x88) & (spk[-1] == 0xAC)
+
+
+
+

--- a/secp256k1.py
+++ b/secp256k1.py
@@ -8,6 +8,7 @@ keys, and is trivially vulnerable to side channel attacks. Do not use for
 anything but tests."""
 import random
 import hashlib
+import hmac
 
 def TaggedHash(tag, data):
     ss = hashlib.sha256(tag.encode('utf-8')).digest()
@@ -468,6 +469,16 @@ class ECPubKey():
     def negate(self):
         self.p = SECP256K1.affine(SECP256K1.negate(self.p))
 
+def rfc6979_nonce(key):
+    """Compute signing nonce using RFC6979."""
+    v = bytes([1] * 32)
+    k = bytes([0] * 32)
+    k = hmac.new(k, v + b"\x00" + key, 'sha256').digest()
+    v = hmac.new(k, v, 'sha256').digest()
+    k = hmac.new(k, v + b"\x01" + key, 'sha256').digest()
+    v = hmac.new(k, v, 'sha256').digest()
+    return hmac.new(k, v, 'sha256').digest()
+
 class ECKey():
     """A secp256k1 private key"""
 
@@ -595,15 +606,18 @@ class ECKey():
         ret.compressed = self.compressed
         return ret
 
-    def sign_ecdsa(self, msg, low_s=True):
+    def sign_ecdsa(self, msg, low_s=True, rfc6979=False):
         """Construct a DER-encoded ECDSA signature with this key.
 
         See https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm for the
         ECDSA signer algorithm."""
         assert(self.valid)
         z = int.from_bytes(msg, 'big')
-        # Note: no RFC6979, but a simple random nonce (some tests rely on distinct transactions for the same operation)
-        k = random.randrange(1, SECP256K1_ORDER)
+        # Note: no RFC6979 by default, but a simple random nonce (some tests rely on distinct transactions for the same operation)
+        if rfc6979:
+            k = int.from_bytes(rfc6979_nonce(self.secret.to_bytes(32, 'big') + msg), 'big')
+        else:
+            k = random.randrange(1, SECP256K1_ORDER)
         R = SECP256K1.affine(SECP256K1.mul([(SECP256K1_G, k)]))
         r = R[0] % SECP256K1_ORDER
         s = (modinv(k, SECP256K1_ORDER) * (z + self.secret * r)) % SECP256K1_ORDER

--- a/send_and_receive_test_vectors.json
+++ b/send_and_receive_test_vectors.json
@@ -8,7 +8,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "46304402200154af1c50b25311614a334c42063991d11900b135893d59080fa25d9b23136102203da3b5ef5230132f162c08b44079cd9e9c30186a14eba585c50d9278f2734e4621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -20,7 +20,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022049a285795ddb08016d1fb0af1b83ca30903167142df2766de459ff25aa83ea07022100c3f0747bb7cc04f437e6c3c64c14443467fae86721f056b8f78e4aeaacd40cb22103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
+                            "scriptSig": "48304602210086783ded73e961037e77d49d9deee4edc2b23136e9728d56e4491c80015c3a63022100fda4c0f21ea18de29edbce57f7134d613e044ee150a89e2e64700de2d4e83d4e2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -54,7 +54,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "46304402200154af1c50b25311614a334c42063991d11900b135893d59080fa25d9b23136102203da3b5ef5230132f162c08b44079cd9e9c30186a14eba585c50d9278f2734e4621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -65,7 +65,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022049a285795ddb08016d1fb0af1b83ca30903167142df2766de459ff25aa83ea07022100c3f0747bb7cc04f437e6c3c64c14443467fae86721f056b8f78e4aeaacd40cb22103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
+                            "scriptSig": "48304602210086783ded73e961037e77d49d9deee4edc2b23136e9728d56e4491c80015c3a63022100fda4c0f21ea18de29edbce57f7134d613e044ee150a89e2e64700de2d4e83d4e2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -107,7 +107,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "47304502207225630c4feb30b5f48fad4a4d93c7b04dcfe594248237b2a7f7c597916adb18022100f335f1481ad578e18a39b91af6b6090b0cb88d66286155f421c75ce80a2bf3ab21025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -119,7 +119,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "473045022007da9cd01d18203deb7d03700add511151640a442938a87800c8ceb65b73b779022100fff9b866a77f71c04029c327769a279c752c7ae9a97e41fe70f8435402bf2f3b2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
+                            "scriptSig": "48304602210086783ded73e961037e77d49d9deee4edc2b23136e9728d56e4491c80015c3a63022100fda4c0f21ea18de29edbce57f7134d613e044ee150a89e2e64700de2d4e83d4e2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -153,7 +153,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "47304502207225630c4feb30b5f48fad4a4d93c7b04dcfe594248237b2a7f7c597916adb18022100f335f1481ad578e18a39b91af6b6090b0cb88d66286155f421c75ce80a2bf3ab21025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -164,7 +164,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "473045022007da9cd01d18203deb7d03700add511151640a442938a87800c8ceb65b73b779022100fff9b866a77f71c04029c327769a279c752c7ae9a97e41fe70f8435402bf2f3b2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
+                            "scriptSig": "48304602210086783ded73e961037e77d49d9deee4edc2b23136e9728d56e4491c80015c3a63022100fda4c0f21ea18de29edbce57f7134d613e044ee150a89e2e64700de2d4e83d4e2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -206,7 +206,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 3,
-                            "scriptSig": "46304402205e25c27d61caaf170eddca2f40fc8ff10671347529d20e8a9ca5513b0edc9fec0220752062d019b87aa05842e204cb1a4310a6d4680b18732fb1c30457a4d753ea5421025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -218,7 +218,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 7,
-                            "scriptSig": "463044022005a446a935c20df86ee87b22f2d3e3a169910a3521d45df0219a831aef717adb0220796a26026ccf7a88b470ac89ffab2454330fd2c7fbf5181d7bfcc98476f000ef2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
+                            "scriptSig": "48304602210086783ded73e961037e77d49d9deee4edc2b23136e9728d56e4491c80015c3a63022100fda4c0f21ea18de29edbce57f7134d613e044ee150a89e2e64700de2d4e83d4e2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -252,7 +252,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 3,
-                            "scriptSig": "46304402205e25c27d61caaf170eddca2f40fc8ff10671347529d20e8a9ca5513b0edc9fec0220752062d019b87aa05842e204cb1a4310a6d4680b18732fb1c30457a4d753ea5421025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -263,7 +263,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 7,
-                            "scriptSig": "463044022005a446a935c20df86ee87b22f2d3e3a169910a3521d45df0219a831aef717adb0220796a26026ccf7a88b470ac89ffab2454330fd2c7fbf5181d7bfcc98476f000ef2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
+                            "scriptSig": "48304602210086783ded73e961037e77d49d9deee4edc2b23136e9728d56e4491c80015c3a63022100fda4c0f21ea18de29edbce57f7134d613e044ee150a89e2e64700de2d4e83d4e2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -305,7 +305,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 7,
-                            "scriptSig": "473045022100dd136328ca4fa8aa29d55e7db064944b469dcbf00a3735b5ba9bc9faf51563c502205e5f52bb9a67daa486b9d173fe4aabd11ae37f1d8367a7a03f6bd9437620aa2e21025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -317,7 +317,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 3,
-                            "scriptSig": "483046022100cb72732ff48f1905fc0630d68f3b2ba405a1867a714677d16d2856acfa11fb06022100c421ed18d26429224bfbd0b6d8cfc18b56bbd5a951bc047d578c7357d1ad90ce2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
+                            "scriptSig": "48304602210086783ded73e961037e77d49d9deee4edc2b23136e9728d56e4491c80015c3a63022100fda4c0f21ea18de29edbce57f7134d613e044ee150a89e2e64700de2d4e83d4e2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -351,7 +351,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 7,
-                            "scriptSig": "473045022100dd136328ca4fa8aa29d55e7db064944b469dcbf00a3735b5ba9bc9faf51563c502205e5f52bb9a67daa486b9d173fe4aabd11ae37f1d8367a7a03f6bd9437620aa2e21025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -362,7 +362,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 3,
-                            "scriptSig": "483046022100cb72732ff48f1905fc0630d68f3b2ba405a1867a714677d16d2856acfa11fb06022100c421ed18d26429224bfbd0b6d8cfc18b56bbd5a951bc047d578c7357d1ad90ce2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
+                            "scriptSig": "48304602210086783ded73e961037e77d49d9deee4edc2b23136e9728d56e4491c80015c3a63022100fda4c0f21ea18de29edbce57f7134d613e044ee150a89e2e64700de2d4e83d4e2103bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -404,7 +404,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "47304502202d96a857596432638c04c90f371271ab10396c78c45890ab89ea403e9b5d0144022100f442e6802565e401d1f16c4732e6a7928f0a16cbca834c79996fc4309e46992221025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -416,7 +416,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "46304402206191694d7280de3010bfa5f2ac342569fb2d17232beaa93fcb3ff3fe19443f9b0220436ab3e61a6f8143dc92e749fa35018b42d5d41ff3ae3eb30c05c9b0e369240921025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -450,7 +450,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "47304502202d96a857596432638c04c90f371271ab10396c78c45890ab89ea403e9b5d0144022100f442e6802565e401d1f16c4732e6a7928f0a16cbca834c79996fc4309e46992221025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -461,7 +461,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "46304402206191694d7280de3010bfa5f2ac342569fb2d17232beaa93fcb3ff3fe19443f9b0220436ab3e61a6f8143dc92e749fa35018b42d5d41ff3ae3eb30c05c9b0e369240921025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -713,7 +713,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022100ab7fda2ecbf0908765e65af3628cad3c0c8901fa502fad078ecb119c6bff5a6f02200a6dcaf3112238203e53e9d2eb64e5373260e3c3d03053ebdda7c684034e7e192103e0ec4f64b3fa2e463ccfcf4e856e37d5e1e20275bc89ec1def9eb098eff1f85d",
+                            "scriptSig": "463044021f24e010c6e475814740ba24c8cf9362c4db1276b7f46a7b1e63473159a80ec30221008198e8ece7b7f88e6c6cc6bb8c86f9f00b7458222a8c91addf6e1577bcf7697e2103e0ec4f64b3fa2e463ccfcf4e856e37d5e1e20275bc89ec1def9eb098eff1f85d",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -758,7 +758,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022100ab7fda2ecbf0908765e65af3628cad3c0c8901fa502fad078ecb119c6bff5a6f02200a6dcaf3112238203e53e9d2eb64e5373260e3c3d03053ebdda7c684034e7e192103e0ec4f64b3fa2e463ccfcf4e856e37d5e1e20275bc89ec1def9eb098eff1f85d",
+                            "scriptSig": "463044021f24e010c6e475814740ba24c8cf9362c4db1276b7f46a7b1e63473159a80ec30221008198e8ece7b7f88e6c6cc6bb8c86f9f00b7458222a8c91addf6e1577bcf7697e2103e0ec4f64b3fa2e463ccfcf4e856e37d5e1e20275bc89ec1def9eb098eff1f85d",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -812,7 +812,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "483046022100e734dc3a2d97a1dece9ba9bb08062fd90db1508f8273b2f15738043966b6e267022100d89eeee97f65b06305627db165a1917a46debfb00332e1fd0a285bdb266210ce2103e0ec4f64b3fa2e463ccfcf4e856e37d5e1e20275bc89ec1def9eb098eff1f85d",
+                            "scriptSig": "463044021f24e010c6e475814740ba24c8cf9362c4db1276b7f46a7b1e63473159a80ec30221008198e8ece7b7f88e6c6cc6bb8c86f9f00b7458222a8c91addf6e1577bcf7697e2103e0ec4f64b3fa2e463ccfcf4e856e37d5e1e20275bc89ec1def9eb098eff1f85d",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -857,7 +857,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "483046022100e734dc3a2d97a1dece9ba9bb08062fd90db1508f8273b2f15738043966b6e267022100d89eeee97f65b06305627db165a1917a46debfb00332e1fd0a285bdb266210ce2103e0ec4f64b3fa2e463ccfcf4e856e37d5e1e20275bc89ec1def9eb098eff1f85d",
+                            "scriptSig": "463044021f24e010c6e475814740ba24c8cf9362c4db1276b7f46a7b1e63473159a80ec30221008198e8ece7b7f88e6c6cc6bb8c86f9f00b7458222a8c91addf6e1577bcf7697e2103e0ec4f64b3fa2e463ccfcf4e856e37d5e1e20275bc89ec1def9eb098eff1f85d",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -899,7 +899,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "483046022100c7522f9d720b9de1624f140664a66635054015855f8534aa68b837de9119dd12022100faef0b8198755324334b6e6145ba5b3789a5bd00349c3c4132135f740d95e0e121025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -911,7 +911,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022100e3e0fb793597bdc92788456930bac26b5c517cccca359bba6ecc35a334117db502204926992a07c6356522e21bbb409837773ad24dc516358fc4040716ac13e0544d2103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -953,7 +953,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "483046022100c7522f9d720b9de1624f140664a66635054015855f8534aa68b837de9119dd12022100faef0b8198755324334b6e6145ba5b3789a5bd00349c3c4132135f740d95e0e121025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -964,7 +964,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022100e3e0fb793597bdc92788456930bac26b5c517cccca359bba6ecc35a334117db502204926992a07c6356522e21bbb409837773ad24dc516358fc4040716ac13e0544d2103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1014,7 +1014,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "483046022100c7522f9d720b9de1624f140664a66635054015855f8534aa68b837de9119dd12022100faef0b8198755324334b6e6145ba5b3789a5bd00349c3c4132135f740d95e0e121025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1026,7 +1026,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022100e3e0fb793597bdc92788456930bac26b5c517cccca359bba6ecc35a334117db502204926992a07c6356522e21bbb409837773ad24dc516358fc4040716ac13e0544d2103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1084,7 +1084,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "483046022100c7522f9d720b9de1624f140664a66635054015855f8534aa68b837de9119dd12022100faef0b8198755324334b6e6145ba5b3789a5bd00349c3c4132135f740d95e0e121025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1095,7 +1095,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022100e3e0fb793597bdc92788456930bac26b5c517cccca359bba6ecc35a334117db502204926992a07c6356522e21bbb409837773ad24dc516358fc4040716ac13e0544d2103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1140,7 +1140,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "483046022100c7522f9d720b9de1624f140664a66635054015855f8534aa68b837de9119dd12022100faef0b8198755324334b6e6145ba5b3789a5bd00349c3c4132135f740d95e0e121025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1151,7 +1151,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022100e3e0fb793597bdc92788456930bac26b5c517cccca359bba6ecc35a334117db502204926992a07c6356522e21bbb409837773ad24dc516358fc4040716ac13e0544d2103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1201,7 +1201,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "473045022100b523454b02843344a8bcd337cefe52bc10c954009bb454a8a8633aca61a8dfb702206944729dcfa5b5a436b7ca90fe4675271be20b8adda63bff43652fba0b97d18221025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1213,7 +1213,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "4730450220727ef4cc1dc06147fa39274343be7e6ad7cf8546f958396362671925bb0b57c9022100e2f7b37b75a86b062d2bbc285c2f3cd22c3332defc55acc6dd9eff0bcad9c2502103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1247,7 +1247,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "473045022100b523454b02843344a8bcd337cefe52bc10c954009bb454a8a8633aca61a8dfb702206944729dcfa5b5a436b7ca90fe4675271be20b8adda63bff43652fba0b97d18221025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1258,7 +1258,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "4730450220727ef4cc1dc06147fa39274343be7e6ad7cf8546f958396362671925bb0b57c9022100e2f7b37b75a86b062d2bbc285c2f3cd22c3332defc55acc6dd9eff0bcad9c2502103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1307,7 +1307,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "483046022100ca692da59cf2f8efe341a5aa476263241fe5a8cc90e7ecf545f865ed0034b289022100b3926f244b09fe05836b47eed006df39bef0ab364bfeffba4df19b82f0b4317b21025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1319,7 +1319,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022048a6a6c6d9f5fac417c5222b11b185a99bceff256cd1d309604817c808145129022100bc4dd76ee06afa7873e2f97557e460bcc16c9347e51ce94c63107bc0ab9cc8f92103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1353,7 +1353,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "483046022100ca692da59cf2f8efe341a5aa476263241fe5a8cc90e7ecf545f865ed0034b289022100b3926f244b09fe05836b47eed006df39bef0ab364bfeffba4df19b82f0b4317b21025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1364,7 +1364,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "473045022048a6a6c6d9f5fac417c5222b11b185a99bceff256cd1d309604817c808145129022100bc4dd76ee06afa7873e2f97557e460bcc16c9347e51ce94c63107bc0ab9cc8f92103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1413,7 +1413,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "47304502200bc5921e439e95cfa2ad15570a49101c025f5fb52553c41070cd63e3476f9a7a0221008ef04d4771d7ab9049c1bb793760c54ecc886f9548181e8d00a0c208f65a45c321025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1425,7 +1425,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "463044022052b8146f207bd2cd7e7171a6973bd89cbc0e28516022bf20d9518f7c1bdf5a3f02203f906d9359843ad28c41abd1f7e756c35aa84b608589c232b7098bb49d3735f42103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1459,7 +1459,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "47304502200bc5921e439e95cfa2ad15570a49101c025f5fb52553c41070cd63e3476f9a7a0221008ef04d4771d7ab9049c1bb793760c54ecc886f9548181e8d00a0c208f65a45c321025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1470,7 +1470,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "463044022052b8146f207bd2cd7e7171a6973bd89cbc0e28516022bf20d9518f7c1bdf5a3f02203f906d9359843ad28c41abd1f7e756c35aa84b608589c232b7098bb49d3735f42103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1519,7 +1519,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "473045022100fce980d0fa17e94938d910c2cb66f511224883c7ff3e25e115e2d5812c6f241f0220286ce7e291d4bfdc369d54dc9b7e79ff10efcd3f36d7ba58d2eda5a375f69f2521025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1531,7 +1531,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "4630440220474a3bcc2475d59bc6e0ac382f5106ddf1e55b0665c6c64b3167e9029273da06022074f1fc2c164bdc324aa355958e316d44a75fc495ef0e79141c26d262ca46f3c82103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1573,7 +1573,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "473045022100fce980d0fa17e94938d910c2cb66f511224883c7ff3e25e115e2d5812c6f241f0220286ce7e291d4bfdc369d54dc9b7e79ff10efcd3f36d7ba58d2eda5a375f69f2521025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1584,7 +1584,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "4630440220474a3bcc2475d59bc6e0ac382f5106ddf1e55b0665c6c64b3167e9029273da06022074f1fc2c164bdc324aa355958e316d44a75fc495ef0e79141c26d262ca46f3c82103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1635,7 +1635,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "4730450220048571714620a23223da78a0c4609125ca09f959960a59b13b5040c17e7bb41b022100ae3264601189699d18af253b3bdf5385e293318759ab3c311b47045ebca446dc21025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1647,7 +1647,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "483046022100cb95f0bd059426489311503b054526ca781f47086acfb1ff29a0fa32b33e5e2c022100b6df6bfb638728f01654b6989a0ae3455d3180c377bc3e3aedf996efe59230812103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1689,7 +1689,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "4730450220048571714620a23223da78a0c4609125ca09f959960a59b13b5040c17e7bb41b022100ae3264601189699d18af253b3bdf5385e293318759ab3c311b47045ebca446dc21025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1700,7 +1700,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "483046022100cb95f0bd059426489311503b054526ca781f47086acfb1ff29a0fa32b33e5e2c022100b6df6bfb638728f01654b6989a0ae3455d3180c377bc3e3aedf996efe59230812103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1751,7 +1751,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "46304402202694ddce946ff9b2214a575e0ed80128153926be3bcfffc16d1dad8e61a23d87022053ecbb8363a6f03d20aa4dbcbbf9edbb0fafed3a6d977e8ee587b52640d6fb3821025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1763,7 +1763,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "463044022065421d39d90057ba75dfe35084df2ffaa10a387037170d13c0417cf6fd2a8ed2022030aa1896d926cff34173851a8c74e62afaa442584fad977e69ff236d6dfd30fe2103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1821,7 +1821,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "46304402202694ddce946ff9b2214a575e0ed80128153926be3bcfffc16d1dad8e61a23d87022053ecbb8363a6f03d20aa4dbcbbf9edbb0fafed3a6d977e8ee587b52640d6fb3821025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1832,7 +1832,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "463044022065421d39d90057ba75dfe35084df2ffaa10a387037170d13c0417cf6fd2a8ed2022030aa1896d926cff34173851a8c74e62afaa442584fad977e69ff236d6dfd30fe2103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1885,7 +1885,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "483046022100f590044abb79f1b07de9ad6470c79a4d07096d20c96bee5c1416492a437ccc6a022100f233e3c37631102eed83e08d77a2b3534e130547141d20316c293bd305eccb5221025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1897,7 +1897,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "4830460221008641c5aaff39d1a57df6a42741f6c2f0f4d7c90407c7ce537a1d2bfbf35ea9f1022100b19b11cb0a08bbbdcab1beed431434e66af18c4bc3449f09e92f2301af1e96aa2103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1939,7 +1939,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "483046022100f590044abb79f1b07de9ad6470c79a4d07096d20c96bee5c1416492a437ccc6a022100f233e3c37631102eed83e08d77a2b3534e130547141d20316c293bd305eccb5221025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1950,7 +1950,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "4830460221008641c5aaff39d1a57df6a42741f6c2f0f4d7c90407c7ce537a1d2bfbf35ea9f1022100b19b11cb0a08bbbdcab1beed431434e66af18c4bc3449f09e92f2301af1e96aa2103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -1991,7 +1991,7 @@
                         {
                             "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
                             "vout": 0,
-                            "scriptSig": "483046022100f590044abb79f1b07de9ad6470c79a4d07096d20c96bee5c1416492a437ccc6a022100f233e3c37631102eed83e08d77a2b3534e130547141d20316c293bd305eccb5221025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                            "scriptSig": "483046022100ad79e6801dd9a8727f342f31c71c4912866f59dc6e7981878e92c5844a0ce929022100fb0d2393e813968648b9753b7e9871d90ab3d815ebf91820d704b19f4ed224d621025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -2002,7 +2002,7 @@
                         {
                             "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
                             "vout": 0,
-                            "scriptSig": "4830460221008641c5aaff39d1a57df6a42741f6c2f0f4d7c90407c7ce537a1d2bfbf35ea9f1022100b19b11cb0a08bbbdcab1beed431434e66af18c4bc3449f09e92f2301af1e96aa2103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                            "scriptSig": "473045022100a8c61b2d470e393279d1ba54f254b7c237de299580b7fa01ffcc940442ecec4502201afba952f4e4661c40acde7acc0341589031ba103a307b886eb867b23b850b972103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
                             "txinwitness": "",
                             "prevout": {
                                 "scriptPubKey": {
@@ -2032,85 +2032,6 @@
                             "signature": "335667ca6cae7a26438f5cfdd73b3d48fa832fa9768521d7d5445f22c203ab0d74ed85088f27d29959ba627a4509996676f47df8ff284d292567b1beef0e3912"
                         }
                     ]
-                }
-            }
-        ]
-    },
-    {
-        "comment": "Skipped tx: unknown segwit version input",
-        "sending": [
-            {
-                "given": {
-                    "inputs": [
-                        {
-                            "prevout": [
-                                "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
-                                0,
-                                "46304402202f6d0422582fba7dd74532acaedf79de1d13cdf14abb6c93eb72c52a4bbf04b6022013025a9f1ff69139f7b9cdffbb84d3770184edd1fb54bac1e78c226d8d1636e421025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
-                                ""
-                            ],
-                            "scriptPubKey": "76a91419c2f3ae0ca3b642bd3e49598b8da89f50c1416188ac",
-                            "private_key": "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1"
-                        },
-                        {
-                            "prevout": [
-                                "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
-                                0,
-                                "",
-                                "0246304402203f7d3b831107d751385aa7e670128735534d0d5076c6766abbcd1f277e5c5b4b0220116e08dadd3650e9de35ced47308aec0d127afaeadc2d5aa0a3d56a4689135b52103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
-                            ],
-                            "scriptPubKey": "52147cdd63cc408564188e8e472640e921c7c90e651d",
-                            "private_key": "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a"
-                        }
-                    ],
-                    "recipients": [
-                        [
-                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
-                            1.0
-                        ]
-                    ]
-                },
-                "expected": {
-                    "outputs": []
-                }
-            }
-        ],
-        "receiving": [
-            {
-                "given": {
-                    "inputs": [
-                        {
-                            "prevout": [
-                                "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
-                                0,
-                                "46304402202f6d0422582fba7dd74532acaedf79de1d13cdf14abb6c93eb72c52a4bbf04b6022013025a9f1ff69139f7b9cdffbb84d3770184edd1fb54bac1e78c226d8d1636e421025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
-                                ""
-                            ],
-                            "scriptPubKey": "76a91419c2f3ae0ca3b642bd3e49598b8da89f50c1416188ac"
-                        },
-                        {
-                            "prevout": [
-                                "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
-                                0,
-                                "",
-                                "0246304402203f7d3b831107d751385aa7e670128735534d0d5076c6766abbcd1f277e5c5b4b0220116e08dadd3650e9de35ced47308aec0d127afaeadc2d5aa0a3d56a4689135b52103782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
-                            ],
-                            "scriptPubKey": "52147cdd63cc408564188e8e472640e921c7c90e651d"
-                        }
-                    ],
-                    "outputs": [
-                        "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
-                        "0250e70ffd828ff655c40c3275d19f5bf4c765abed0b9afc1c328cfe364e931b"
-                    ],
-                    "key_material": {
-                        "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
-                        "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c"
-                    },
-                    "labels": []
-                },
-                "expected": {
-                    "addresses": [],
-                    "outputs": []
                 }
             }
         ]


### PR DESCRIPTION
* use deterministic sigs for ecdsa (rfc6979)
  * non-determinism was causing a lot of noise
* move general bitcoin code into bitcoin_utils 
  * this keeps reference.py as specific to silent payments as possible
* check for compressed pubkeys
  * per the bip, only compressed pubkeys are allowed add checks to p2wpkh, p2pkh, since these could have uncompressed / hybrid keys (need test cases for these)
* rename input_nonce to input_hash